### PR TITLE
handle utf-8 and out of range -h parameter

### DIFF
--- a/x_x/asciitable.py
+++ b/x_x/asciitable.py
@@ -18,7 +18,7 @@ def write_bytes(s, out, encoding="utf-8"):
             else:
                 out.write(bytes(s, encoding))
         else:
-            out.write(s)
+            out.write(s.encode(encoding, 'replace'))
     except IOError as bpe:
         exit()
 
@@ -123,7 +123,10 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
 
     cols, lines = termsize()
     headings = list(cursor.keys())
-    heading_sizes = [len(str(x)) for x in headings]
+    if PY3:
+        heading_sizes = [len(str(x)) for x in headings]
+    else:
+        heading_sizes = [len(unicode(x)) for x in headings]
     if paginate:
         cursor = isublists(cursor, lines - 4)
         # else we assume cursor arrive here pre-paginated
@@ -134,7 +137,10 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
                 break
             for idx, value in enumerate(row):
                 if not isinstance(value, string_types):
-                    value = str(value)
+                    if PY3:
+                        value = str(value)
+                    else:
+                        value = unicode(value)
                 size = max(sizes[idx], len(value))
                 sizes[idx] = min(size, max_fieldsize)
         draw_headings(headings, sizes)
@@ -146,16 +152,15 @@ def draw(cursor, out=sys.stdout, paginate=True, max_fieldsize=100):
                 if idx < len(rw):
                     value = rw[idx]
                     if not isinstance(value, string_types):
-                        value = str(value)
+                        if PY3:
+                            value = str(value)
+                        else:
+                            value = unicode(value)
                     if len(value) > max_fieldsize:
                         value = value[:max_fieldsize - 5] + '[...]'
                     value = value.replace('\n', '^')
                     value = value.replace('\r', '^').replace('\t', ' ')
                     value = fmt % value
-                    try:
-                        value = value.encode('utf-8', 'replace')
-                    except UnicodeDecodeError:
-                        value = fmt % '?'
                     write_bytes(value, out)
             write_bytes('|\n', out)
         if not paginate:

--- a/x_x/x_x.py
+++ b/x_x/x_x.py
@@ -2,6 +2,7 @@ import itertools
 import string
 import os
 import subprocess
+import sys
 
 import click
 import xlrd
@@ -41,7 +42,11 @@ class XCursor(object):
 @click.argument('filename')
 def cli(filename, heading):
     """ things and stuff about stuff and things """
-    workbook = xlrd.open_workbook(filename)
+    try:
+        workbook = xlrd.open_workbook(filename)
+    except Exception as e:
+        sys.exit(e)
+
     sheet = workbook.sheet_by_index(0)
     out = subprocess.Popen(
         'less -FXRiS', shell=True, bufsize=0, stdin=subprocess.PIPE).stdin

--- a/x_x/x_x.py
+++ b/x_x/x_x.py
@@ -12,8 +12,11 @@ from . import asciitable
 class XCursor(object):
 
     def __init__(self, sheet, headingrow=None):
-        self.headingrow = headingrow
         self.sheet = sheet
+        if 0 <= headingrow < self.sheet.nrows:
+            self.headingrow = headingrow
+        else:
+            self.headingrow = None 
 
     def keys(self):
         if self.headingrow is not None:


### PR DESCRIPTION
I think this solves #8 and add some python3 compat changes. I let the write_bytes() do the encoding instead of repeating it along the code every time before calling it. 

I also added something to the XCursor class to handle when user gives an out of range row number to --heading.

Had initially sent a pull request through another fork with the exit gracefully, now it's here. 
